### PR TITLE
Updated to work with latest version of React Native (0.37.0+)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
-var React = require('react-native')
+var React = require('react')
+var ReactNative = require('react-native')
 var styles = require('./style')
 
+var {PropTypes} = React
 var {
   View,
   Text,
-  TouchableOpacity,
-  PropTypes
-} = React
+  TouchableOpacity
+} = ReactNative
 
 var Spinner = React.createClass({
   propTypes: {


### PR DESCRIPTION
Updated to work with latest version of React Native (0.37.0+). (the "PropTypes" class is now held in the "react" module, rather than the "react-native"--I suppose because they want to share code with react-js where they overlap)