### PR TITLE
Add controlled property `value`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Property          | Description | Type | Default | Note
 ------------------|-------------|------|---------|-------
 max               | | number | 0  |
 min               | | number | 99 |
-default           | default number of the Spinner | number | 0 |
+default           | default number of the Spinner | number | 0 | You can define either `default` or `value`.
+value             | controlled value of the Spinner | number | undefined | If `value` is defined, then the value can change only via the property. This means that `onNumChange` must be defined and change external state.
 color             | custom color of the Spinner | string | '#33c9d6' |
 numColor          | custom number color | string | '#333' |
 numBgColor        | background color of number button | string | 'white' |

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var Spinner = React.createClass({
     min: PropTypes.number,
     max: PropTypes.number,
     default: PropTypes.number,
+    value: PropTypes.number,
     color: PropTypes.string,
     numColor: PropTypes.string,
     numBgColor: PropTypes.string,
@@ -48,7 +49,25 @@ var Spinner = React.createClass({
     return {
       min: this.props.min,
       max: this.props.max,
-      num: this.props.default
+      num: typeof this.props.value !== 'undefined' ? this.props.value : this.props.default
+    }
+  },
+
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.min) {
+      this.setState({
+        min: nextProps.min
+      })
+    }
+    if (nextProps.max) {
+      this.setState({
+        max: nextProps.max
+      })
+    }
+    if (nextProps.value) {
+      this.setState({
+        num: nextProps.value
+      })
     }
   },
 
@@ -60,10 +79,12 @@ var Spinner = React.createClass({
     if (this.props.disabled) return
 
     if (this.state.max > this.state.num) {
-      var num = this.state.num
-      this.setState({
-        num: ++num
-      })
+      var num = this.state.num + 1
+      if (typeof this.props.value === 'undefined') {
+        this.setState({
+          num: num
+        })
+      }
 
       this._onNumChange(num)
     }
@@ -73,11 +94,12 @@ var Spinner = React.createClass({
     if (this.props.disabled) return
 
     if (this.state.min < this.state.num) {
-      var num = this.state.num
-
-      this.setState({
-        num: --num
-      })
+      var num = this.state.num - 1
+      if (typeof this.props.value === 'undefined') {
+        this.setState({
+          num: num
+        })
+      }
 
       this._onNumChange(num)
     }


### PR DESCRIPTION
I came across a need to dynamically update the value of the spinner besides for having the user change it.

To solve the problem, i added a controlled prop `value`, which can be used instead of `default`. If `value` is defined, then the state will only change in response to a prop change.  
This does not change the behavior when only using `default`.